### PR TITLE
Parse only part of data buffer

### DIFF
--- a/src/fast-http.lisp
+++ b/src/fast-http.lisp
@@ -225,12 +225,12 @@
                                  (setq completedp t)))))
     (setf (http-store-body http) store-body)
     (return-from make-parser
-      (named-lambda http-parser-execute (data)
+      (named-lambda http-parser-execute (data &key (start 0) end)
         (cond
           ((eql data :eof)
            (when finish-callback
              (funcall (the function finish-callback))))
-          (T (http-parse parser callbacks (the simple-byte-vector data))
+          (T (http-parse parser callbacks (the simple-byte-vector data) :start start :end end)
              (when (and (or body-callback
                             (http-store-body http))
                         header-complete-p)


### PR DESCRIPTION
Can be useful with non-blocking IO, e.g. we do non-blocking read and it fills our buffer only partially but with bounds support we still can parse data immediately without copying. 

Example usage:

``` lisp
(funcall parser data :start 0 :end read-bytes)
```
