### PR TITLE
Reset completedp when keep-alive, parse content length and transfer encoding when store-body is T

### DIFF
--- a/src/fast-http.lisp
+++ b/src/fast-http.lisp
@@ -161,7 +161,7 @@
                                   (parser-status-code parser))
                             (setf (http-status-text http)
                                   (babel:octets-to-string data :start start :end end))))
-             :header-field (and (or header-callback body-callback)
+             :header-field (and (or header-callback body-callback store-body)
                                 (named-lambda header-field-cb (parser data start end)
                                   (declare (ignore parser)
                                            (type simple-byte-vector data))
@@ -190,7 +190,7 @@
                                         (parse-header-value parser data start end))))
                              (cond
                                (header-callback #'parse-header-value)
-                               (body-callback #'parse-header-value-only-some-headers)))
+                               ((or body-callback store-body) #'parse-header-value-only-some-headers)))
              :headers-complete (named-lambda headers-complete-cb-with-callback (parser)
                                  (setq header-complete-p t)
                                  (setf (http-version http)
@@ -267,7 +267,7 @@
                   (setq completedp t))))
              (when (and completedp finish-callback)
                (funcall (the function finish-callback)))))
-        (values http header-complete-p completedp)))))
+        (values http header-complete-p (when completedp (setf completedp nil) t))))))
 
 (defun find-boundary (content-type)
   (declare (type string content-type))


### PR DESCRIPTION
**_Keep-alive and completedp**_
`completedp` should be reset to nil immediately after it returned as T. Or all subsequent parser invocations will invoke `finish-callback` and of course return T as third value

Response:

``` lisp
 (let* ((response (list #?"HTTP/1.1 200 OK\r\n"
                                #?"Content-Length:  2  \r\n"
                                #?"\r\n"
                                #?"qw"
                                #?"HTTP/1.1 499 This probably should be printed once\r\n"
                                #?"Content-Length:  2  \r\n"
                                #?"\r\n"
                                #?"qw"))
                (http (fast-http:make-http-response))
                (parser (fast-http:make-parser http :finish-callback (lambda () (print http)))))
           (loop for res-chunk in response do              
             (when (nth-value 2 (funcall parser (trivial-utf-8:string-to-utf-8-bytes res-chunk)))
               (print "Message Completed!"))))

#S(FAST-HTTP.HTTP:HTTP-RESPONSE
   :VERSION 11/10
   :HEADERS {

   }
   :STORE-BODY NIL
   :FORCE-STREAM NIL
   :BODY NIL
   :STATUS 200
   :STATUS-TEXT "OK") 
"Message Completed!" 
#S(FAST-HTTP.HTTP:HTTP-RESPONSE
   :VERSION 11/10
   :HEADERS {

   }
   :STORE-BODY NIL
   :FORCE-STREAM NIL
   :BODY NIL
   :STATUS 499
   :STATUS-TEXT "This probably should be printed once") 
"Message Completed!" 
#S(FAST-HTTP.HTTP:HTTP-RESPONSE
   :VERSION 11/10
   :HEADERS {

   }
   :STORE-BODY NIL
   :FORCE-STREAM NIL
   :BODY NIL
   :STATUS 499
   :STATUS-TEXT "This probably should be printed once") 
"Message Completed!" 
#S(FAST-HTTP.HTTP:HTTP-RESPONSE
   :VERSION 11/10
   :HEADERS {

   }
   :STORE-BODY NIL
   :FORCE-STREAM NIL
   :BODY NIL
   :STATUS 499
   :STATUS-TEXT "This probably should be printed once") 
"Message Completed!" 
#S(FAST-HTTP.HTTP:HTTP-RESPONSE
   :VERSION 11/10
   :HEADERS {

   }
   :STORE-BODY NIL
   :FORCE-STREAM NIL
   :BODY NIL
   :STATUS 499
   :STATUS-TEXT "This probably should be printed once") 
"Message Completed!"


```

Request:

``` lisp
(let* ((request (list #?"POST / HTTP/1.1\r\n"
                              #?"Host: www.example.com\r\n"
                              #?"Content-Type: application/x-www-form-urlencoded\r\n"
                              #?"Content-Length: 4\r\n"
                              #?"\r\n"
                              #?"q=42\r\n"
                              #?"POST / HTTP/1.1\r\n"
                              #?"Host: www.example.com\r\n"
                              #?"Content-Type: application/x-www-form-urlencoded\r\n"
                              #?"Content-Length: 4\r\n"
                              #?"\r\n"
                              #?"q=42\r\n"))
                    (http (fast-http:make-http-request :store-body t ))
                    (parser (fast-http:make-parser http :store-body t )))
               (loop for req-chunk in request do              
                 (when (nth-value 2 (funcall parser (trivial-utf-8:string-to-utf-8-bytes req-chunk)))
                   (print "Message Completed!"))))

"Message Completed!" 
"Message Completed!" 
"Message Completed!" 
"Message Completed!" 
"Message Completed!" 
"Message Completed!" 
"Message Completed!" 
"Message Completed!" 
```

**_:store-body t**_

While exploring `completedp` problem I noticed this:

``` lisp
 (let* ((request (list #?"POST / HTTP/1.1\r\n"
                              #?"Host: www.example.com\r\n"
                              #?"Content-Type: application/x-www-form-urlencoded\r\n"
                              #?"Content-Length: 4 \r\n"
                              #?"\r\n"
                              #?"q=42\r\n"))
                    (http (fast-http:make-http-request :store-body t ))
                    (parser (fast-http:make-parser http :store-body t )))
               (loop for req-chunk in request do              
                 (when (nth-value 2 (funcall parser (trivial-utf-8:string-to-utf-8-bytes req-chunk)))
                   (print "Message Completed!"))))

"Message Completed!" 
"Message Completed!"
```

Here we have just single request, however "Message Completed!" printed twice. Because there no callbacks, headers in highlevel parser were not parsed at all and the following `cond` clause executed and reset `completedp` to `T`:

``` lisp
(T
    ;; No Content-Length, no chunking, probably a request with no body
    (setq completedp t))
```
