### PR TITLE
Add .travis.yml for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ script:
                  (lambda (c h)
                    (declare (ignore c h))
                    (uiop:quit -1)))'
+       -e '(ql:quickload :cl-syntax)'
        -e '(ql:quickload :fast-http)'
        -e '(asdf:test-system :fast-http)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,5 @@ script:
                  (lambda (c h)
                    (declare (ignore c h))
                    (uiop:quit -1)))'
-       -e '(ql:quickload :cl-syntax)'
-       -e '(ql:quickload :fast-http)'
+       -e '(ql:quickload (list :cl-interpol :cl-syntax :fast-http))'
        -e '(asdf:test-system :fast-http)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ script:
                    (uiop:quit -1)))'
        -e '(ql:quickload (list :cl-interpol :cl-syntax :fast-http))'
        -e '(asdf:test-system :fast-http)'
+       -e '(let ((test-results (asdf:find-system :fast-http-test)))
+             (or test-results
+                 (uiop:quit -1)))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: common-lisp
+
+env:
+  matrix:
+    - LISP=sbcl
+
+install:
+  # Install cl-travis
+  - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | bash
+
+script:
+  - cl -e '(ql:quickload :prove)'
+       -e '(setf prove:*debug-on-error* t)'
+       -e '(setf *debugger-hook*
+                 (lambda (c h)
+                   (declare (ignore c h))
+                   (uiop:quit -1)))'
+       -e '(asdf:test-system :fast-http)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ script:
                  (lambda (c h)
                    (declare (ignore c h))
                    (uiop:quit -1)))'
+       -e '(ql:quickload :fast-http)'
        -e '(asdf:test-system :fast-http)'


### PR DESCRIPTION
I wrote a little `.travis.yml` file for automatically testing `fast-http`, and also because people seem to like those cute "build: passing" badges. [This](https://travis-ci.org/eudoxia0/fast-http/builds/45546840) is what testing looks like.

If you are willing to sign up for Travis I would be very happy to write the `.travis.yml` files for a couple other important projects of yours.