### PR TITLE
handle the case where there are multiple headers with same name and are ...

### DIFF
--- a/src/fast-http.lisp
+++ b/src/fast-http.lisp
@@ -129,7 +129,8 @@
                  (multiple-value-bind (previous-value existp)
                      (gethash (the simple-string parsing-header-field) headers)
                    (setf (gethash (the simple-string parsing-header-field) headers)
-                         (if existp
+                         (if (and existp
+                                  (simple-string-p previous-value))
                              (concatenate 'string (the simple-string previous-value) ", " header-value)
                              (if (number-string-p header-value)
                                  (read-from-string header-value)


### PR DESCRIPTION
...numbers. (ex: there are two "age: 0" headers), example site that has this issue (http://www.sonosite.com)