### PR TITLE
Fix interning when *print-case* is not :upcase.

### DIFF
--- a/src/multipart-parser.lisp
+++ b/src/multipart-parser.lisp
@@ -21,6 +21,7 @@
   (:import-from :babel
                 :string-to-octets)
   (:import-from :alexandria
+                :format-symbol
                 :when-let)
   (:export :ll-multipart-parser
            :ll-multipart-parser-state
@@ -58,7 +59,7 @@
                             maybe-delimiter-second-dash
                             body-almost-done
                             body-done)
-             collect `(defconstant ,(intern (format nil "+~A+" state)) ,i)))
+             collect `(defconstant ,(format-symbol t "+~A+" state) ,i)))
 
 (defun http-multipart-parse (parser callbacks data &key (start 0) end)
   (declare (type simple-byte-vector data))

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -17,6 +17,7 @@
                 :casev=
                 :case-byte)
   (:import-from :alexandria
+                :format-symbol
                 :with-gensyms
                 :hash-table-alist
                 :define-constant
@@ -69,22 +70,22 @@ us a never-ending header that the application keeps buffering.")
 
 (defmacro callback-data (name http callbacks data start end)
   (with-gensyms (callback e)
-    `(when-let (,callback (,(intern (format nil "~A-~A" :callbacks name)) ,callbacks))
+    `(when-let (,callback (,(format-symbol t "~A-~A" :callbacks name) ,callbacks))
        (handler-bind ((error
                         (lambda (,e)
                           (unless (typep ,e 'fast-http-error)
-                            (error ',(intern (format nil "~A-~A" :cb name))
+                            (error ',(format-symbol t "~A-~A" :cb name)
                                    :error ,e)
                             (abort ,e)))))
          (funcall ,callback ,http ,data ,start ,end)))))
 
 (defmacro callback-notify (name http callbacks)
   (with-gensyms (callback e)
-    `(when-let (,callback (,(intern (format nil "~A-~A" :callbacks name)) ,callbacks))
+    `(when-let (,callback (,(format-symbol t "~A-~A" :callbacks name) ,callbacks))
        (handler-bind ((error
                         (lambda (,e)
                           (unless (typep ,e 'fast-http-error)
-                            (error ',(intern (format nil "~A-~A" :cb name))
+                            (error ',(format-symbol t "~A-~A" :cb name)
                                    :error ,e)
                             (abort ,e)))))
          (funcall ,callback ,http)))))


### PR DESCRIPTION
`(intern (format "~a" symbol))` depends on `*print-case*` and usually produces unintented results when compiled on a system with a different `*print-case*`. This patch makes fast-http work independtly from `*print-case*`. I checked that tests pass after applying the patch.