### PR TITLE
remove bogus type declaration for next in parse-headers

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -441,7 +441,6 @@ us a never-ending header that the application keeps buffering.")
             (error 'header-overflow))
           (multiple-value-bind (next endp)
               (parse-header-line http callbacks data (pos) end)
-            (declare (type (unsigned-byte 8) next))
             (advance-to* next)
             (when endp
               (return)))


### PR DESCRIPTION
 * alternatively, this could probably be (declare (type pointer next)), but I'm not sure we need that.

A trivial change, but one that shows up if you remove all of the various speed/safety declarations. Next can legitimately be > 255, so this declaration is wrong.