### PR TITLE
Support HTTP pipelining.

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -511,7 +511,12 @@ us a never-ending header that the application keeps buffering.")
            ;; Assume content-length 0 - read the next
            (progn
              (message-complete)
-             end)
+             ;; By returning "start", we'll continue
+             ;; to parse the next request in case if
+             ;; HTTP pipelining is used. Probably
+             ;; we need some way to enable (or disable)
+             ;; HTTP pipelining support.
+             start)
            ;; read until EOF
            (progn
              (callback-data :body http callbacks data start end)


### PR DESCRIPTION
I'm optimizing Common Lisp app used in https://github.com/TechEmpower/FrameworkBenchmarks and some tests are requiring from HTTP server support of HTTP pipelining.

This patch adds such support.

More details about what it is can be found here:

https://en.wikipedia.org/wiki/HTTP_pipelining
https://www.rfc-editor.org/rfc/rfc7230.txt
