### PR TITLE
Parser wasn't callend message-complete for HEAD responses.

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -474,7 +474,7 @@ us a never-ending header that the application keeps buffering.")
           (decf (http-content-length http) readable-count)
           (callback-data :body http callbacks data start end)
           (setf (http-mark http) end)
-          (values end nil)))))
+          (values end (= readable-count 0))))))
 
 (defun-speedy http-message-needs-eof-p (http)
   (let ((status-code (http-status http)))
@@ -521,6 +521,7 @@ us a never-ending header that the application keeps buffering.")
            (progn
              (callback-data :body http callbacks data start end)
              (setf (http-mark http) end)
+	     (message-complete)
              end)))
       (otherwise
        ;; Content-Length header given and non-zero


### PR DESCRIPTION
When using carrier  HEAD requests would error out despite the header callback looking good.

The message-complete callback wasn't being called when there was no body to parse, so now the parser checks if it's at the end of the data once parsing the headers.